### PR TITLE
Version 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fixfasta.py
 
-Version 1.0 - June 28, 2025
+Version 1.1 - June 30, 2025
 
 A tool for automatically fixing the orientation of fungal ITS sequences in FASTA files. Perfect for cleaning up sequences downloaded from databases like MycoMap or GenBank where some sequences might be reverse-complemented.
 
@@ -133,6 +133,44 @@ mafft sequences_oriented.fasta > aligned.fasta
 - The tool preserves sequence names exactly 
 - Handles messy FASTA files gracefully (like those with stray '>' symbols)
 - All diagnostic output goes to stderr, so stdout piping remains clean
+
+
+---
+
+# getfasta.py
+
+Version 1.0 – June 30, 2025
+
+A tiny helper that grabs the FASTA files behind a **MycoMap BLAST** result page – no clicking, no copy‑and‑paste, just the files on disk ready to go. As of v1.1 it also tells you **how many sequences** were retrieved.
+
+## What it does
+
+* Pulls the **NCBI‑side** FASTA (`ncbi_<ID>.fasta`) and the **local MycoMap** FASTA (`myco_<ID>.fasta`) for a given BLAST job.
+* Prints the download time, file size **and** sequence count for each file.
+* Names everything with the BLAST numeric ID.
+
+## Example
+
+```bash
+python getfasta.py https://mycomap.com/genetics/blast-search/a04-inat237420128-1-ric77-332392-r265167/
+```
+
+Output looks like this:
+
+```
+Downloading FASTA files for MycoBLAST ID: 265167
+NCBI downloaded in 2.85s (74953 bytes, 97 sequences)
+MycoBLAST downloaded in 1.02s (36161 bytes, 50 sequences)
+```
+
+## How it works
+
+`getfasta.py` digs the numeric `r<digits>` ID out of whatever MycoMap BLAST URL you throw at it, then hits two internal endpoints:
+
+* `do=fasta`  – the NCBI sequences MycoMap pulled in for the search
+* `do=localFasta` – the local, user‑contributed sequences MycoMap keeps
+
+Each response is saved verbatim, then the script counts lines that start with `>` to report the number of sequences.
 
 ## License
 

--- a/fixfasta.py
+++ b/fixfasta.py
@@ -2,7 +2,7 @@
 """
 fixfasta.py — robust auto-orientation of fungal ITS reads
 
-Version 1.0 - June 28, 2025
+Version 1.1 - June 30, 2025
 
 By Alan Rockefeller 
 
@@ -429,10 +429,6 @@ def main():
             print(f"Reverse:         {stats.get('reverse', 0)}", file=sys.stderr)
             print(f"Uncertain:       {stats.get('uncertain', 0)}", file=sys.stderr)
             print(f"Empty:           {stats.get('empty', 0)}", file=sys.stderr)
-        
-        # Cleanup
-        if output_file is not None:
-            output_file.close()
         
     except KeyboardInterrupt:
         logging.error("Aborted by user (KeyboardInterrupt)")

--- a/getfasta.py
+++ b/getfasta.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+"""
+Mycomap FASTA downloader 
+
+By Alan Rockefeller - June 30, 2025.   Version 1.0
+"""
+
+import urllib.request
+import urllib.parse
+import sys
+import re
+import time
+
+if len(sys.argv) < 2:
+    print("Usage: python getfasta.py <MycoBLAST-result-URL>")
+    sys.exit(1)
+
+# Helper 
+def count_fasta_seqs(fasta_bytes: bytes) -> int:
+    """Return the number of sequences in a FASTA file (bytes)."""
+    return sum(1 for line in fasta_bytes.splitlines() if line.startswith(b'>'))
+
+# Parse URL 
+blast_id_match = re.search(r'r(\d+)', sys.argv[1])
+if not blast_id_match:
+    print("Could not find an r<digits> pattern in the URL you provided.")
+    sys.exit(1)
+
+blast_id = blast_id_match.group(1)
+print(f"Downloading FASTA files for MycoBLAST ID: {blast_id}")
+
+# HTTP opener - #
+base_url = "https://mycomap.com/index.php"
+opener = urllib.request.build_opener()
+opener.addheaders = [
+    ('User-Agent', 'curl/7.68.0'),
+    ('Accept', '*/*')
+]
+
+total_start = time.time()
+
+# NCBI download #
+params_ncbi = urllib.parse.urlencode({
+    'app': 'genbank',
+    'module': 'genbank',
+    'controller': 'blast',
+    'do': 'fasta',
+    'id': blast_id
+})
+url_ncbi = f"{base_url}?{params_ncbi}"
+t0 = time.time()
+with opener.open(url_ncbi) as resp:
+    ncbi_bytes = resp.read()
+ncbi_time = time.time() - t0
+
+with open(f'ncbi_{blast_id}.fasta', 'wb') as fh:
+    fh.write(ncbi_bytes)
+
+ncbi_seqs = count_fasta_seqs(ncbi_bytes)
+print(f"NCBI downloaded in {ncbi_time:.2f}s "
+      f"({len(ncbi_bytes)} bytes, {ncbi_seqs} sequences)")
+
+# MycoBLAST download 
+params_myco = urllib.parse.urlencode({
+    'app': 'genbank',
+    'module': 'genbank',
+    'controller': 'blast',
+    'do': 'localFasta',
+    'id': blast_id
+})
+url_myco = f"{base_url}?{params_myco}"
+t0 = time.time()
+with opener.open(url_myco) as resp:
+    myco_bytes = resp.read()
+myco_time = time.time() - t0
+
+with open(f'myco_{blast_id}.fasta', 'wb') as fh:
+    fh.write(myco_bytes)
+
+myco_seqs = count_fasta_seqs(myco_bytes)
+print(f"MycoBLAST downloaded in {myco_time:.2f}s "
+      f"({len(myco_bytes)} bytes, {myco_seqs} sequences)")
+


### PR DESCRIPTION
Adds getfasta.py, a script to download FASTA files from MycoBLAST result pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new tool to automate downloading FASTA files from MycoMap BLAST result pages, saving files locally and reporting download time, file size, and sequence count.

* **Documentation**
  * Updated the README to include details and usage examples for the new FASTA download tool.
  * Updated version information for an existing script. 

* **Refactor**
  * Improved file handling in an existing script for safer resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->